### PR TITLE
Wrap exports as an object so that it can be called with new. (Fix for #15)

### DIFF
--- a/lib/recurly.js
+++ b/lib/recurly.js
@@ -11,6 +11,8 @@ var
 	;
 //----------------------------------------------------------------------------------------
 
+function recurring() {
+
 var extend = function() {
 	var args = Array.prototype.slice.call(arguments);
 	var base = args.shift() || {};
@@ -1402,17 +1404,24 @@ FormResponseToken.prototype.process = function(callback)
 };
 
 
+recurring.prototype.Account = Account;
+recurring.prototype.Addon = Addon;
+recurring.prototype.Adjustment = Adjustment;
+recurring.prototype.BillingInfo = BillingInfo;
+recurring.prototype.Coupon = Coupon;
+recurring.prototype.Invoice = Invoice;
+recurring.prototype.Plan = Plan;
+recurring.prototype.Redemption = Redemption;
+recurring.prototype.Subscription = Subscription;
+recurring.prototype.Transaction = Transaction;
+recurring.prototype.FormResponseToken = FormResponseToken;
+recurring.prototype.setAPIKey = setAPIKey;
+
+}
+
+
 // ----------------------------------------------------------------------
 
-exports.Account = Account;
-exports.Addon = Addon;
-exports.Adjustment = Adjustment;
-exports.BillingInfo = BillingInfo;
-exports.Coupon = Coupon;
-exports.Invoice = Invoice;
-exports.Plan = Plan;
-exports.Redemption = Redemption;
-exports.Subscription = Subscription;
-exports.Transaction = Transaction;
-exports.FormResponseToken = FormResponseToken;
-exports.setAPIKey = setAPIKey;
+module.exports = function() {
+  return new recurring();
+}


### PR DESCRIPTION
This change wraps the recurring module exports in a function, enabling new instances to be created by instantiating a new object. For example, with this change you can do:

```
var recurly = require('recurring');

var recurly1 = new recurly;
recurly1.Plan.all(function (res) { ... });

var recurly2 = new recurly;
recurly2.Plan.all(function (res) { ... });
```

Where recurly1 and recurly2 are both separate instances of the recurly object with their own internal caches.