### PR TITLE
Fixes invalid_state error on Invoice#all

### DIFF
--- a/lib/models/invoice.js
+++ b/lib/models/invoice.js
@@ -56,14 +56,15 @@ class Invoice extends RecurlyData {
   }
 
   all(state, callback) {
+    let url = Invoice.ENDPOINT
+
     if (typeof callback === 'undefined' && typeof state === 'function') {
       callback = state
-      state = 'active'
+    } else {
+      url += `?${querystring.stringify({ state })}`
     }
 
-    this.fetchAll('Invoice', `${Invoice.ENDPOINT}?${querystring.stringify({
-      state
-    })}`, (err, results) => {
+    this.fetchAll('Invoice', url, (err, results) => {
       const data = { }
       _.each(results, invoice => {
         data[invoice.uuid] = invoice


### PR DESCRIPTION
When calling the Invoice.all(function), I was seeing this error:

```
state_invalid
Invalid state (must be one of open, processing, collected, failed, past_due)
```

This is because the `state` query param was defaulting to `active` which
is not an invoice state (though it is a Subscription state). I think it
should default to not passing a state filter by default (which basically
means all invoices regardless of state).

\cc @mrfelton 