### PR TITLE
Fixes the broken invoice test

### DIFF
--- a/lib/models/account.js
+++ b/lib/models/account.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Adjustment = require('./account')
+const Adjustment = require('./adjustment')
 const RecurlyData = require('../recurly-data')
 const _ = require('lodash')
 const handleRecurlyError = require('../util').handleRecurlyError

--- a/lib/models/adjustment.js
+++ b/lib/models/adjustment.js
@@ -11,7 +11,10 @@ class Adjustment extends RecurlyData {
         'currency',
         'single_use',
         'state',
-        'total_discounted_in_cents'
+        'total_discounted_in_cents',
+        'unit_amount_in_cents',
+        'quantity',
+        'description'
       ],
       idField: '',
       plural: 'adjustments',


### PR DESCRIPTION
This fixes the integration test that was failing on every run. I fixed
it by having the setup callback create an open invoice for the test to
find. It creates an account, then an adjustment, then an invoice.

I also noticed that the Account model file was requiring the account as
`Adjustment`.

I also added some properties to the adjustment that were
missing.

It's still failing intermittently due to one of the invoice refund tests. I'll have a look at why that's happening when I get the chance.

\cc @mrfelton 