### PR TITLE
fix: do not require setup fee in plan create

### DIFF
--- a/lib/models/plan.js
+++ b/lib/models/plan.js
@@ -87,9 +87,6 @@ class Plan extends RecurlyData {
     if (!options.name) {
       throw (new Error('plan options must include "name" parameter'))
     }
-    if (!options.setup_fee_in_cents) {
-      throw (new Error('plan options must include "setup_fee_in_cents" parameter'))
-    }
     if (!options.unit_amount_in_cents) {
       throw (new Error('plan options must include "unit_amount_in_cents" parameter'))
     }

--- a/test/test-02-api.js
+++ b/test/test-02-api.js
@@ -33,9 +33,6 @@ describe('Plan', () => {
     const data = {
       plan_code: `testplan${planId}`,
       name: `Test Plan ${planId}`,
-      setup_fee_in_cents: {
-        USD: 199
-      },
       unit_amount_in_cents: {
         USD: 1000
       }
@@ -48,6 +45,49 @@ describe('Plan', () => {
       newPlan.name.must.equal(data.name)
       done()
     })
+  })
+
+  it('cannot create a plan without a plan code', done => {
+    const planId = uuid.v4()
+    const wrong = () => {
+      const inadequate = {
+        name: `Test Plan ${planId}`,
+        unit_amount_in_cents: {
+          USD: 1000
+        }
+      }
+      recurly.Plan().create(inadequate, _.noop)
+    }
+    wrong.must.throw(Error)
+    done()
+  })
+
+  it('cannot create a plan without a plan name', done => {
+    const planId = uuid.v4()
+    const wrong = () => {
+      const inadequate = {
+        plan_code: `testplan${planId}`,
+        unit_amount_in_cents: {
+          USD: 1000
+        }
+      }
+      recurly.Plan().create(inadequate, _.noop)
+    }
+    wrong.must.throw(Error)
+    done()
+  })
+
+  it('cannot create a plan without a plan unit amount in cents', done => {
+    const planId = uuid.v4()
+    const wrong = () => {
+      const inadequate = {
+        plan_code: `testplan${planId}`,
+        name: `Test Plan ${planId}`
+      }
+      recurly.Plan().create(inadequate, _.noop)
+    }
+    wrong.must.throw(Error)
+    done()
   })
 
   it('can fetch all plans from the test Recurly account', done => {


### PR DESCRIPTION
Recurly does not require setup_fee_in_cents when creating a plan
https://dev.recurly.com/v2.0/docs/create-plan so recurring should not
require this either.

I've also added some tests for errors thrown when required fields are missing.