### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/signer.js
+++ b/lib/signer.js
@@ -2,7 +2,7 @@
 
 const crypto = require('crypto')
 const qs = require('qs')
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 
 class SignedQuery {
   constructor(key) {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "data2xml": "1.2.5",
     "debug": "2.2.0",
     "lodash": "4.16.4",
-    "node-uuid": "1.4.7",
     "qs": "6.2.1",
     "request": "2.75.0",
     "throttled-request": "0.1.1",
+    "uuid": "3.0.0",
     "xml2js": "0.4.17"
   },
   "devDependencies": {

--- a/test/test-02-api.js
+++ b/test/test-02-api.js
@@ -2,7 +2,7 @@
 
 const demand = require('must')
 const Recurring = require('../lib/recurly')
-const uuid = require('node-uuid')
+const uuid = require('uuid')
 const debug = require('debug')('recurring:test')
 const _ = require('lodash')
 

--- a/test/test-05-cache.js
+++ b/test/test-05-cache.js
@@ -8,7 +8,7 @@
 //   parser = require('../lib/parser'),
 //   Recurring = require('../lib/recurly'),
 //   util = require('util'),
-//   uuid = require('node-uuid'),
+//   uuid = require('uuid'),
 //   iterators = require('async-iterators'),
 //   _ = require('lodash')
 //


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.