### PR TITLE
use invoice number instead of invoice uuid

### DIFF
--- a/lib/models/invoice.js
+++ b/lib/models/invoice.js
@@ -37,7 +37,7 @@ class Invoice extends RecurlyData {
         'uuid',
         'vat_number'
       ],
-      idField: 'uuid',
+      idField: 'invoice_number',
       plural: 'invoices',
       singular: 'invoice'
     })


### PR DESCRIPTION
The invoice is looked up in the api by its `invoice_number`. This makes the `invoice_number` effectively its `id`.