### PR TITLE
fix: handle string types in arrays

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -19,8 +19,16 @@ function parseTypes(input) {
         if (Array.isArray(item)) {
           result = [ ]
           for (let j = 0; j < item.length; j++) {
-            result.push(parseTypes(item[j]))
+            if (typeof item[j] === 'string') {
+              result.push(item[j])
+            }
+            else {
+              result.push(parseTypes(item[j]))
+            }
           }
+        }
+        else if (typeof item === 'string') {
+          result = [ item ]
         }
         else {
           result = [ parseTypes(item) ]

--- a/test/fixtures/coupon_01.xml
+++ b/test/fixtures/coupon_01.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<coupon href="https://api.recurly.com/v2/coupons/test">
+  <redemptions href="https://api.recurly.com/v2/coupons/test/redemptions"/>
+  <coupon_code>test</coupon_code>
+  <name>Test Coupon</name>
+  <state>redeemable</state>
+  <description>This is a description of a coupon</description>
+  <discount_type>percent</discount_type>
+  <discount_percent type="integer">50</discount_percent>
+  <redeem_by_date nil="nil"></redeem_by_date>
+  <single_use type="boolean">true</single_use>
+  <applies_for_months nil="nil"></applies_for_months>
+  <max_redemptions nil="nil"></max_redemptions>
+  <applies_to_all_plans type="boolean">true</applies_to_all_plans>
+  <created_at type="datetime">2012-11-21T01:27:10Z</created_at>
+  <plan_codes type="array">
+    <plan_code>one</plan_code>
+  </plan_codes>
+  <a name="redeem" href="https://api.recurly.com/v2/coupons/test/redeem" method="post"/>
+</coupon>

--- a/test/fixtures/coupon_02.xml
+++ b/test/fixtures/coupon_02.xml
@@ -14,7 +14,8 @@
   <applies_to_all_plans type="boolean">true</applies_to_all_plans>
   <created_at type="datetime">2012-11-21T01:27:10Z</created_at>
   <plan_codes type="array">
+    <plan_code>one</plan_code>
+    <plan_code>two</plan_code>
   </plan_codes>
   <a name="redeem" href="https://api.recurly.com/v2/coupons/test/redeem" method="post"/>
 </coupon>
-

--- a/test/test-01-parser.js
+++ b/test/test-01-parser.js
@@ -158,4 +158,33 @@ describe('recurly xml parser', () => {
       done()
     })
   })
+
+  it('can parse sample coupon xml with one plan_code', done => {
+    const data = readFixture('coupon_01.xml')
+    rparser.parseXML(data, (err, result) => {
+      demand(err).not.exist()
+      result.must.not.be.an.array()
+      result.must.have.property('href')
+      result.must.have.property('plan_codes')
+      result.plan_codes.must.be.an.array()
+      result.plan_codes.length.must.equal(1)
+      result.plan_codes[0].must.equal('one')
+      done()
+    })
+  })
+
+  it('can parse sample coupon xml with multiple plan_codes', done => {
+    const data = readFixture('coupon_02.xml')
+    rparser.parseXML(data, (err, result) => {
+      demand(err).not.exist()
+      result.must.not.be.an.array()
+      result.must.have.property('href')
+      result.must.have.property('plan_codes')
+      result.plan_codes.must.be.an.array()
+      result.plan_codes.length.must.equal(2)
+      result.plan_codes[0].must.equal('one')
+      result.plan_codes[1].must.equal('two')
+      done()
+    })
+  })
 })


### PR DESCRIPTION
The parser was assuming all children of an array were object, but could
be strings, such as plan_codes in a coupon