### PR TITLE
fix(Account): Submit account address on update

### DIFF
--- a/lib/models/account.js
+++ b/lib/models/account.js
@@ -124,7 +124,8 @@ class Account extends RecurlyData {
       first_name: this.first_name,
       last_name: this.last_name,
       company_name: this.company_name,
-      accept_language: this.accept_language
+      accept_language: this.accept_language,
+      address: this.address
     }
 
     if (this.billing_info) {

--- a/test/test-02-api.js
+++ b/test/test-02-api.js
@@ -195,6 +195,26 @@ describe('Account', () => {
       })
     })
   })
+
+  it('can update an account address', done => {
+    account.address = {
+      address1: '760 Market Street',
+      address2: 'Suite 500'
+    }
+    account.update((err, updated) => {
+      demand(err).not.exist()
+      updated.must.be.an.object()
+
+      const testAcc = recurly.Account()
+      testAcc.id = account.id
+      testAcc.fetch(err => {
+        demand(err).not.exist()
+        testAcc.address.address1.must.equal(account.address.address1)
+        testAcc.address.address2.must.equal(account.address.address2)
+        done()
+      })
+    })
+  })
 })
 
 describe('BillingInfo', () => {


### PR DESCRIPTION
It's possible to set address attributes on account creation, but it didn't seem to be possible to update it later. This PR should make it possible.