### PR TITLE
Adds Pause Subscription functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,13 @@ Reactivate a cancelled subscription.
 subscription.reactivate(function(err, updated));
 ```
 
+**subscription.pause()**  
+Pause a subscription.
+
+```javascript
+subscription.pause(remainingPauseCycles, function(err, updated));
+```
+
 **subscription.postpone()**  
 Postpone a subscription.
 

--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -181,6 +181,36 @@ class Subscription extends RecurlyData {
     })
   }
 
+  pause(remainingPauseCycles, callback) {
+    if (!this.id) {
+      throw (new Error('cannot pause a subscription without a uuid'))
+    }
+    if (!remainingPauseCycles || (typeof remainingPauseCycles !== 'number')) {
+      throw (new Error(`${remainingPauseCycles} must be a valid number of billing cycles to pause`))
+    }
+
+    let href
+    if (this.a && this.a.pause) {
+      href = this.a.pause.href
+    }
+    else {
+      href = `${Subscription.ENDPOINT}/${this.id}/pause`
+    }
+
+    const query = { remaining_pause_cycles: remainingPauseCycles }
+    href += `?${querystring.stringify(query)}`
+
+    this.put(href, '', (err, response, payload) => {
+      const error = handleRecurlyError(err, response, payload, [ 200 ])
+      if (error) {
+        return callback(error)
+      }
+
+      this.inflate(payload)
+      callback(null, this)
+    })
+  }
+
   postpone(nextRenewal, callback) {
     if (!this.id) {
       throw (new Error('cannot postpone a subscription without a uuid'))

--- a/test/test-02-api.js
+++ b/test/test-02-api.js
@@ -449,6 +449,16 @@ describe('Subscription', () => {
     })
   })
 
+  it('can pause a subscription', done => {
+    const remainingPauseCycles = 1;
+
+    subscription.pause(remainingPauseCycles, err => {
+      demand(err).not.exist()
+      subscription.remaining_pause_cycles.must.equal(remainingPauseCycles)
+      done()
+    })
+  })
+
   it('can postpone a subscription', done => {
     const now = new Date()
     const nextDate = new Date(now.getUTCFullYear(), now.getUTCMonth() + 1, 1)


### PR DESCRIPTION
Adds subscription.pause() functionality to mirror addition to Recurly's API:
https://dev.recurly.com/docs/pause-subscription

Modeled the code from subscription.postpone(). Adds a test and adds brief documentation to README.

Thanks for a very helpful client.